### PR TITLE
Fix buffer overflow issue (#1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["ScottPJones <scottjones@alum.mit.edu>"]
 keywords = ["Strings", "ICU", "Encoding", "Regex"]
 license = "MIT"
 uuid = "124badd8-7747-5df6-9c35-5cbf8cd52816"
-version = "0.2.1"
 
 [deps]
 Libdl   = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -14,7 +13,7 @@ BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 ModuleInterfaceTools = "5cb8414e-7aab-5a03-a681-351269c074bf"
 StrBase = "e79e7a6a-7bb1-5a4d-9d64-da657b06f53a" # 2v12uwlr0ueale6n
 
-#WinRPM  = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
+WinRPM  = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
 
 [extras]
 Test    = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,4 @@ CharSetEncodings 0.2.0
 ChrBase 0.2.0
 MurmurHash3 0.2.0
 StrBase 0.2.0
-#@windows WinRPM
+@windows WinRPM

--- a/src/ucal.jl
+++ b/src/ucal.jl
@@ -144,7 +144,7 @@ end
 
 function get_default_timezone()
     bufsz = 64
-    buf,pnt = _allocate(UInt16, bufsz)
+    buf, pnt = _allocate(UInt16, bufsz)
     err = Ref{UErrorCode}(0)
     len = ccall(@libcal(getDefaultTimeZone), Int32,
                 (Ptr{UChar}, Int32, Ptr{UErrorCode}),

--- a/src/ucasemap.jl
+++ b/src/ucasemap.jl
@@ -27,18 +27,19 @@ for f in (:ToLower, :ToUpper, :FoldCase, :ToTitle)
                   (Ptr{Cvoid}, Ptr{UInt8}, Int32, Ptr{UInt8}, Int32, Ptr{UErrorCode}),
                   casemap[], dest, destsiz, src, srclen, err)
         function ($lf)(str::ByteStr)
-            destsiz = srclen = sizeof(str)
-            dest = _allocate(srclen)
+            dstlen = srclen = sizeof(str)
+            dest = _allocate(dstlen)
             err = Ref{UErrorCode}(0)
-            siz = ($uf)(dest, destsiz, str, srclen, err)
+            siz = ($uf)(dest, dstlen, str, srclen, err)
             # Retry with large enough buffer if got buffer overflow
             if err[] == U_BUFFER_OVERFLOW_ERROR
                 err[] = 0
-                dest = _allocate(destsiz)
-                siz = ($uf)(dest, destsiz, str, srclen, err)
+                dstlen = siz
+                dest = _allocate(dstlen)
+                siz = ($uf)(dest, dstlen, str, srclen, err)
             end
             FAILURE(err[]) && error("failed to map case: $(err[])")
-            siz != destsiz ? cvt_utf8(dest[1:destsiz]) : cvt_utf8(dest)
+            siz != dstlen ? cvt_utf8(dest[1:siz]) : cvt_utf8(dest)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,13 @@ using StrICU
 let str = "\u3b0",
     upp = "\u3a5\u308\u301"
 
+    @test ICU.toupper(str^8) == upp^8
     @test ICU.toupper(ICU.cvt_utf16(str^8)) == ICU.cvt_utf16(upp^8)
+
+    # Fix PR #1
+    set_locale!("tr_TR")
+    @test ICU.tolower("AI") == "aı"
+    set_locale!("")
 end
 
 @testset "utext" begin


### PR DESCRIPTION
The code needed to correctly handle the result being shorter or longer than the input string.
This worked for the `Str` types such as `UTF16Str`, which is what ICU is normally used with,
but not for `String`.
